### PR TITLE
Adapt customer_churn_month for active customers

### DIFF
--- a/models/customer_churn_month.sql
+++ b/models/customer_churn_month.sql
@@ -20,6 +20,7 @@ joined as (
     from mrr
 
     where is_last_month
+    and date_trunc(date_month, MONTH) != date_trunc(DATE_SUB(current_date(), INTERVAL 1 MONTH), MONTH)
 
 )
 


### PR DESCRIPTION
Hi there!

First of all, thank you for this playbook. It was _exactly_ what I needed.

Regarding this change, the objetive here is to deal with customers that never churned (having null for their end of subscription column). As it is now, the model generates churn months for the entire customer base at the end of period. While this is easy to disregard in analysis by removing the last month from the range I thought it would make more sense to never generate churn months for the active customers.

I used CURRENT_DATE but I have the feeling I should have used the date spine.
Does this make sense? If yes, what would be the best way to achieve this?